### PR TITLE
fix: add network to plugs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,3 +23,4 @@ apps:
     command: bin/glow
     plugs:
       - home
+      - network


### PR DESCRIPTION
Glow can also render things directly from the internet, in which case the network plug is required.